### PR TITLE
fix(deps): revert to Python 3.10.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.0b5-slim
+FROM python:3.10.6-slim
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Dependabot moved to 3.11.0b5 rather than 3.10.6, which causes pip to attempt to compile C dependencies, which fails because the slim image doesn't have g++

**- What I did**

Bumped back to 3.10.6 (previously 3.10.5)

**- How to verify it**

Actions should run clean by getting .whl dependency from Pypi rather than downloading a tarball and trying to compile it.

**- Description for the changelog**

fix(deps): revert to Python 3.10.6