### PR TITLE
build(deps): use requirements.txt for image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM python:3.10.7-slim
 
 WORKDIR /usr/src/app
 
-RUN pip3 install --no-cache-dir google-cloud-monitoring
+COPY ["docker_send_data.py", "requirements.txt", "./"]
 
-COPY docker_send_data.py .
+RUN pip3 install -r requirements.txt
 
 CMD [ "python3", "./docker_send_data.py" ]


### PR DESCRIPTION
**- What I did**

Modified Dockerfile to pull pinned dependencies from requirements.txt

**- How to verify it**

Local testing has been done to verify that the Dockerfile creates an image

**- Description for the changelog**

build(deps): use requirements.txt for image builds