### PR TITLE
ci: Add Docker image signing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,23 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      docker:
+        patterns:
+          - "*"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      pip:
+        patterns:
+          - "*"

--- a/.github/workflows/at_swarm_load_docker.yml
+++ b/.github/workflows/at_swarm_load_docker.yml
@@ -6,30 +6,48 @@ on:
     branches:
       - "trunk"
 
+permissions:
+  contents: read
 
 jobs:
   build_multi_arch_images:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1.7.0
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1.14.1 
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
+        with:
+          tags: |
+            type=raw,value=latest
+            type=raw,value=GHA_${{ github.run_number }}
+          images: |
+            atsigncompany/at_swarm_load
+          labels: |
+            org.opencontainers.image.description=Atsign Swarm Load
+
       - name: Build and push at_swarm_load
         id: docker_build
-        uses: docker/build-push-action@v2.10.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           push: true
-          tags: |
-            atsigncompany/at_swarm_load:latest
-            atsigncompany/at_swarm_load:GHA_${{ github.run_number }}
+          sbom: true
+          provenance: version=v1,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           platforms: |
             linux/amd64

--- a/.github/workflows/at_swarm_load_docker.yml
+++ b/.github/workflows/at_swarm_load_docker.yml
@@ -10,8 +10,13 @@ permissions:
   contents: read
 
 jobs:
-  build_multi_arch_images:
+  build_image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # for creating OIDC tokens for signing.
+    outputs:
+      digest: ${{ steps.docker_build.outputs.digest }}
     steps:
       - name: Check out code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -51,3 +56,17 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: |
             linux/amd64
+
+  slsa_provenance:
+    needs: [build_image]
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      image: "atsigncompany/at_swarm_load"
+      digest: ${{ needs.build_image.outputs.digest }}
+    secrets:
+      registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<img width=250px src="https://atsign.dev/assets/img/atPlatform_logo_gray.svg?sanitize=true">
+<a href="https://atsign.com#gh-light-mode-only"><img width=250px src="https://atsign.com/wp-content/uploads/2022/05/atsign-logo-horizontal-color2022.svg#gh-light-mode-only" alt="The Atsign Foundation"></a><a href="https://atsign.com#gh-dark-mode-only"><img width=250px src="https://atsign.com/wp-content/uploads/2023/08/atsign-logo-horizontal-reverse2022-Color.svg#gh-dark-mode-only" alt="The Atsign Foundation"></a>
+
+[![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 
 # At_Swarm_Load
 
@@ -65,6 +67,33 @@ sudo systemctl enable gcp-mon.service
 sudo systemctl start gcp-mon.service
 ```
 
+## SLSA
+
+The Docker images created from this repo have SLSA Build Level 3 attestations.
+
+These can be verified using the
+[slsa-verifier](https://github.com/slsa-framework/slsa-verifier) tool e.g.:
+
+```sh
+IMAGE="atsigncompany/at_swarm_load:latest"
+SHA=$(docker buildx imagetools inspect ${IMAGE} \
+  --format "{{json .Manifest}}" | jq -r .digest)
+slsa-verifier verify-image ${IMAGE}@${SHA} \
+  --source-uri github.com/atsign-company/at_swarm_load
+```
+
+## Docker image signing
+
+This images from this repo are signed during the build process so that you
+can verify their authenticity using
+[cosign](https://github.com/sigstore/cosign):
+
+```sh
+cosign verify atsigncompany/at_swarm_load:latest \
+--certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+--certificate-identity-regexp='^https://github.com/atsign-company/at_swarm_load/.+'
+```
+
 ## Maintainers
 
-Created by @cpswan
+Created by [@cpswan](https://github.com/cpswan)


### PR DESCRIPTION
Progresses https://github.com/atsign-foundation/operations/issues/304

**- What I did**

* Added image signing
* Added SLSA attestations and badges
* Grouping for Dependabot
* New logo for README

**- How I did it**

Based on https://github.com/atsign-foundation/at_server/pull/2411

**- How to verify it**

After this is merged there should be a new image created that can be verified.

**- Description for the changelog**

ci: Add Docker image signing