### PR TITLE
ci: Add Docker image signing block

### DIFF
--- a/.github/workflows/at_swarm_load_docker.yml
+++ b/.github/workflows/at_swarm_load_docker.yml
@@ -57,6 +57,17 @@ jobs:
           platforms: |
             linux/amd64
 
+      - name: Sign the images with GitHub OIDC Token
+        env:
+          DIGEST: ${{ steps.docker_build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --yes ${images}
+
   slsa_provenance:
     needs: [build_image]
     permissions:


### PR DESCRIPTION
#75 was missing a block for the signing :facepalm: 

**- What I did**

Added signing block

**- How I did it**

Copied from at_c_buildimage

**- How to verify it**

Verify signing of image created after this PR is merged

**- Description for the changelog**

ci: Add Docker image signing block